### PR TITLE
Bump configgin version to 0.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DUMB_INIT_VER=1.2.1
 RUN curl -L "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VER}/dumb-init_${DUMB_INIT_VER}_amd64" -o /usr/bin/dumb-init && chmod a+x /usr/bin/dumb-init
 
 # Install configgin
-ARG CONFIGGIN_VER=0.15.0
+ARG CONFIGGIN_VER=0.15.1
 RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin ${CONFIGGIN_VER:+--version=${CONFIGGIN_VER}}"
 
 # Install Python.

--- a/ci/build-bcf-stemcell-ubuntu.yml
+++ b/ci/build-bcf-stemcell-ubuntu.yml
@@ -85,7 +85,7 @@ jobs:
           build_args:
             BASE_IMAGE: bluebosh/bcf-base-image-ubuntu-trusty:latest
             DUMB_INIT_VER: 1.2.1
-            CONFIGGIN_VER: 0.15.0
+            CONFIGGIN_VER: 0.15.1
             UBUNTU_VER: trusty
         get_params:
           skip_download: true
@@ -118,7 +118,7 @@ jobs:
           build_args:
             BASE_IMAGE: bluebosh/bcf-base-image-ubuntu-xenial:latest
             DUMB_INIT_VER: 1.2.1
-            CONFIGGIN_VER: 0.15.0
+            CONFIGGIN_VER: 0.15.1
             UBUNTU_VER: xenial
         get_params:
           skip_download: true


### PR DESCRIPTION
Bump the version of `configgin` to https://rubygems.org/gems/configgin/versions/0.15.1, which includes a fix for multiple container export properties that are used to resolve BOSH links. This resolves https://github.com/SUSE/configgin/issues/72.