### PR TITLE
Bumping configgin version to 0.16.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DUMB_INIT_VER=1.2.1
 RUN curl -L "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VER}/dumb-init_${DUMB_INIT_VER}_amd64" -o /usr/bin/dumb-init && chmod a+x /usr/bin/dumb-init
 
 # Install configgin
-ARG CONFIGGIN_VER=0.15.2
+ARG CONFIGGIN_VER=0.16.2
 RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin ${CONFIGGIN_VER:+--version=${CONFIGGIN_VER}}"
 
 # Install Python.

--- a/ci/build-bcf-stemcell-ubuntu.yml
+++ b/ci/build-bcf-stemcell-ubuntu.yml
@@ -85,7 +85,7 @@ jobs:
           build_args:
             BASE_IMAGE: bluebosh/bcf-base-image-ubuntu-trusty:latest
             DUMB_INIT_VER: 1.2.1
-            CONFIGGIN_VER: 0.15.2
+            CONFIGGIN_VER: 0.16.2
             UBUNTU_VER: trusty
         get_params:
           skip_download: true
@@ -213,4 +213,4 @@ resources:
       bucket: bcf-stemcell-ubuntu
       versioned_file: bcf-stemcell-ubuntu-xenial-version
       access_key_id: {{aws-access-key}}
-      secret_access_key: {{aws-secret-key}}      
+      secret_access_key: {{aws-secret-key}}


### PR DESCRIPTION
Reasons behind are:
- Need it for SCF v2.11.0 bump
- 0.16.2 contains two IBM prs merged, 0.16.0 does not

Signed-off-by: Enrique Encalada <encalada@de.ibm.com>