### PR TITLE
Revert "Merge pull request #7 from bluebosh/bump-configgin-0.20.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DUMB_INIT_VER=1.2.1
 RUN curl -L "https://github.com/Yelp/dumb-init/releases/download/v${DUMB_INIT_VER}/dumb-init_${DUMB_INIT_VER}_amd64" -o /usr/bin/dumb-init && chmod a+x /usr/bin/dumb-init
 
 # Install configgin
-ARG CONFIGGIN_VER=0.20.0
+ARG CONFIGGIN_VER=0.19.0
 RUN /bin/bash -c "source /usr/local/rvm/scripts/rvm && gem install configgin ${CONFIGGIN_VER:+--version=${CONFIGGIN_VER}}"
 
 # Install tools and libraries, as well as removing unwanted software


### PR DESCRIPTION
This commit is to rollback the configgin release from 0.20.0 back to 0.19.0

v0.20.0 is not needed at the moment. While we are currently working on SCF 2.19.1 , v0.20.0 will be required once me bump to an SCF 2.20.0

